### PR TITLE
add BASE_API constant and APIPath global mixin

### DIFF
--- a/src/constants/connection.js
+++ b/src/constants/connection.js
@@ -1,0 +1,8 @@
+const production_api = "https://api.whynot.earth/api/v0";
+const development_api = "https://stagingapi.whynot.earth/api/v0";
+let base_api = production_api;
+if (process.env.NODE_ENV === "development") {
+  base_api = development_api;
+}
+
+export const BASE_API = base_api;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,5 @@
+import { BASE_API } from "@/constants/connection";
+
+export function APIPath(path) {
+  return BASE_API + path
+}

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import VueHead from 'vue-head'
 import VueMarkdown from 'vue-markdown'
 import {store} from './store/store'
 import './registerServiceWorker'
+import '@/mixins.global.js'
 
 // import './sitemapMiddleware'
 // import VueRouterSitemap from 'vue-router-sitemap'

--- a/src/mixins.global.js
+++ b/src/mixins.global.js
@@ -1,0 +1,8 @@
+import Vue from 'vue'
+import connection from "@/mixins/connection.js";
+
+Vue.mixin({
+  methods: {
+    ...connection
+  }
+})

--- a/src/mixins/connection.js
+++ b/src/mixins/connection.js
@@ -1,0 +1,5 @@
+import { APIPath } from "@/helpers.js";
+
+export default {
+  APIPath
+};


### PR DESCRIPTION
There is a global mixin `APIPath()` that you can use this way in every component: `this.APIPath('/pages/slug/vkirirom/categories/by-name/experiences')`.

It will return:  
In process.env.NODE_ENV = production: `https://api.whynot.earth/api/v0/pages/slug/vkirirom/categories/by-name/experiences`  
In process.env.NODE_ENV = development: `https://stagingapi.whynot.earth/api/v0/pages/slug/vkirirom/categories/by-name/experiences`  
#152 