### PR TITLE
367 add snackbar on login, signup and logout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,15 +2,18 @@
   <v-app class="wrapper" :class="hiddenLanguagesClasses" id="app">
     <!-- TODO: remove :key similar to https://github.com/whynotearth/shinta-mani-wild/pull/298 -->
     <router-view :key="$route.name + ($route.params.id || '')" />
+    <snackbars-global></snackbars-global>
   </v-app>
 </template>
 
 <script>
 import store from '@/store'
 import { languageCodes } from '@/constants/app'
+import SnackbarsGlobal from '@/components/SnackbarsGlobal.vue'
 
 export default {
   name: 'app',
+  components: { SnackbarsGlobal },
   created() {
     this.getUser()
     this.clearTemporaryStates()

--- a/src/components/AuthLogin.vue
+++ b/src/components/AuthLogin.vue
@@ -128,12 +128,19 @@ export default {
     updateActiveState(value) {
       store.dispatch('auth/updateActiveState', value)
     },
-    login() {
-      store.dispatch('auth/login').catch(error => {
+    async login() {
+      try {
+        await store.dispatch('auth/loginStandard')
+        store.dispatch('snackbar/show', {
+          color: 'success',
+          text: 'Logging in was successful'
+        })
+      } catch (error) {
         console.log('wrong credentials')
-      })
+      }
     },
     oauth(provider) {
+      // TODO: move to store
       store.commit('auth/updateProvider', provider)
       window.location.assign(store.getters['auth/oauth'])
       store.dispatch('auth/ping')

--- a/src/components/AuthLoginExistingAccount.vue
+++ b/src/components/AuthLoginExistingAccount.vue
@@ -94,8 +94,16 @@ export default {
     updateActiveState(value) {
       store.dispatch('auth/updateActiveState', value)
     },
-    login() {
-      store.dispatch('auth/login')
+    async login() {
+      try {
+        await store.dispatch('auth/loginStandard')
+        store.dispatch('snackbar/show', {
+          color: 'success',
+          text: 'Logging in was successful'
+        })
+      } catch (error) {
+        console.log('wrong credentials')
+      }
     }
   },
   computed: {

--- a/src/components/AuthSignup.vue
+++ b/src/components/AuthSignup.vue
@@ -77,6 +77,7 @@ export default {
       store.dispatch('auth/updateActiveState', value)
     },
     oauth(provider) {
+      // TODO: move to store
       store.commit('auth/updateProvider', provider)
       window.location.assign(store.getters['auth/oauth'])
       store.dispatch('auth/ping')

--- a/src/components/AuthSignupByEmail.vue
+++ b/src/components/AuthSignupByEmail.vue
@@ -158,10 +158,16 @@ export default Vue.extend({
     updateActiveState(value) {
       store.dispatch('auth/updateActiveState', value)
     },
-    submit() {
-      store.dispatch('auth/register').catch(error => {
+    async submit() {
+      try {
+        await store.dispatch('auth/register')
+        store.dispatch('snackbar/show', {
+          color: 'success',
+          text: 'Signing up was successful'
+        })
+      } catch (error) {
         console.log('Signup failed')
-      })
+      }
     },
     oauth(provider) {
       store.commit('auth/updateProvider', provider)

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -218,8 +218,19 @@ export default {
     }
   },
   methods: {
-    logout() {
-      store.dispatch('auth/logout')
+    async logout() {
+      try {
+        await store.dispatch('auth/logout')
+        store.dispatch('snackbar/show', {
+          color: 'success',
+          text: 'Logging out was successful'
+        })
+      } catch (error) {
+        store.dispatch('snackbar/show', {
+          color: 'error',
+          text: 'Logging out was unsuccessful'
+        })
+      }
     },
     openLogin() {
       this.drawer = false

--- a/src/components/SnackbarsGlobal.vue
+++ b/src/components/SnackbarsGlobal.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-snackbar
+    :color="model.color"
+    :timeout="model.timeout"
+    :bottom="model.bottom"
+    :left="model.left"
+    :right="model.right"
+    v-model="isVisible"
+  >
+    {{ model.text }}
+  </v-snackbar>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import store from '../store'
+export default Vue.extend({
+  name: 'snackbars-global',
+  computed: {
+    model() {
+      return store.getters['snackbar/item']
+    },
+    isVisible: {
+      get() {
+        return store.getters['snackbar/item'].visible
+      },
+      set(value) {
+        store.dispatch('snackbar/updateVisibility', value)
+      }
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,6 +8,7 @@ import language from './modules/language'
 import resort from './modules/resort'
 import category from './modules/category'
 import loading from './modules/loading'
+import snackbar from './modules/snackbar'
 import VuexPersistence from 'vuex-persist'
 
 const vuexLocal = new VuexPersistence({
@@ -21,6 +22,7 @@ Vue.use(Vuex)
 export default new Vuex.Store({
   plugins: [vuexLocal.plugin],
   modules: {
+    snackbar,
     loading,
     auth,
     resort,

--- a/src/store/modules/auth.ts
+++ b/src/store/modules/auth.ts
@@ -34,12 +34,6 @@ const defaultState = {
   dialog: {
     title: 'Log In',
     isOpen: false
-  },
-  snackbar: {
-    timeout: 3000,
-    type: 'success',
-    isOpen: false,
-    message: ''
   }
 }
 
@@ -49,9 +43,6 @@ export default {
   getters: {
     dialog: state => {
       return state.dialog
-    },
-    snackbar: state => {
-      return state.snackbar
     },
     activeState: state => {
       return state.activeState
@@ -118,9 +109,6 @@ export default {
     updateActiveState(state, payload) {
       state.activeState = payload
     },
-    updateSnackbar(state, payload) {
-      state.snackbar = payload
-    },
     resetState(state) {
       for (const key in defaultState) {
         if (defaultState.hasOwnProperty(key)) {
@@ -142,13 +130,6 @@ export default {
       setDocumentClassesOnToggleDialog(dialog.isOpen)
       context.commit('updateDialog', dialog)
     },
-    updateSnackbar(context, payload) {
-      const snackbar = {
-        ...context.state.snackbar,
-        ...payload
-      }
-      context.commit('updateSnackbar', snackbar)
-    },
     updateActiveState(context, payload) {
       context.commit('updateActiveState', payload)
       context.commit('updateLoginError', '')
@@ -159,7 +140,7 @@ export default {
         title: authStates[payload].title
       })
     },
-    login(context) {
+    loginStandard(context) {
       context.commit('updateLoginError', '')
       context.commit('updateLoading', true)
       return new Promise((resolve, reject) => {

--- a/src/store/modules/snackbar.ts
+++ b/src/store/modules/snackbar.ts
@@ -1,0 +1,42 @@
+const defaultSettings = {
+  text: '',
+  visible: false,
+  color: 'success',
+  timeout: 3000,
+  bottom: true,
+  left: false,
+  right: false
+}
+
+export default {
+  namespaced: true,
+  state: {
+    item: { ...defaultSettings }
+  },
+  mutations: {
+    update(state, payload) {
+      state.item = payload
+    },
+    updateVisibility(state, payload) {
+      state.item.visible = payload
+    }
+  },
+  actions: {
+    show(context, payload) {
+      const settings = {
+        ...defaultSettings,
+        ...payload,
+        visible: true
+      }
+      context.commit('update', settings)
+    },
+    updateVisibility(context, payload) {
+      context.commit('updateVisibility', payload)
+    }
+  },
+  getters: {
+    item(state) {
+      return state.item
+    }
+  }
+}


### PR DESCRIPTION
- Add snackbar notification on logout, signup by email and log in by email
- Add a global snackbar component and snackbar store
#367 

Sentences:  

> Logging in was successful
> Logging out was successful
> Logging out was unsuccessful
> Signing up was successful