### PR TITLE
home - fix this.resort undefined

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -464,7 +464,7 @@ export default {
   },
   computed: {
     resort(): Resort {
-      return store.getters['resort/getResort']
+      return store.getters['resort/itemBySlug']('home')
     }
   },
   created() {


### PR DESCRIPTION
@paulchrisluke We use `title` property for homepage browser title. It's better to change `title: Home` to `title: vKirirom Pine Resort`.

https://stagingapi.whynot.earth/api/v0/pages/slug/vkirirom/home